### PR TITLE
Bugfix/teste client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,5 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+arquivos/ 


### PR DESCRIPTION

# 🚀 Pull Request

## 📋 Descrição
Este PR tem como objetivo adicionar a pasta `arquivos` no `.gitignore` para evitar poluição no repositório com arquivos locais.

⚠️ Obs: Inicialmente, esta branch foi criada para realizar um bugfix relacionado ao `teste-client`. No entanto, o problema foi resolvido na branch da terceira task. Portanto, utilizei esta branch para subir apenas a alteração no `.gitignore`.

## 🔗 Issue Relacionada
Nenhuma issue diretamente relacionada.

## 🛠️ Alterações Realizadas
- ✅ Adicionada a pasta `arquivos` no arquivo `.gitignore`.
- ✅ Melhoria na organização do repositório, evitando arquivos desnecessários.

## 🧪 Como Testar
1. Verificar que a pasta `arquivos` não é mais rastreada pelo Git.
2. Criar arquivos dentro da pasta `arquivos` e rodar:  
   ```bash
   git status
   ```  
   ✅ Eles não devem aparecer como arquivos não rastreados.

## ✅ Checklist
- [x] Meu código segue os padrões de estilo deste projeto.
- [x] Realizei uma auto-revisão do meu código.
- [x] Comentei meu código, principalmente em partes difíceis de entender (não aplicável aqui).
- [x] Fiz testes locais e eles passaram.
- [ ] Adicionei testes que cobrem minhas alterações (não aplicável).
- [ ] Documentei minhas alterações no README ou na documentação (não aplicável).

## 📸 Evidências (opcional)
Sem necessidade para essa alteração.

## ⚠️ Observações
- Essa alteração é simples, focada exclusivamente na melhoria da organização do repositório através do `.gitignore`.
